### PR TITLE
PY3 compatibility change for A* solver

### DIFF
--- a/solutions/A_star.py
+++ b/solutions/A_star.py
@@ -35,7 +35,7 @@ class AstarPathFinder(object):
     def neighbors(self):
         borders = [(20, 0), (-20, 0), (0, 20), (0, -20)]
         cost_cal = lambda x, y: x - y
-        adjacent_walls = [map(cost_cal, self.current, i) for i in borders]
+        adjacent_walls = [list(map(cost_cal, self.current, i)) for i in borders]
         return [tuple(n) for n in adjacent_walls if n in self.paths] 
         
     def pathfinder(self):


### PR DESCRIPTION
Was returning `NoneType` because of the use of `map` without converting explicitly to `list` type.